### PR TITLE
fix: correct decryption test with different keypairs

### DIFF
--- a/src/crypto/keypair/secp256k1.rs
+++ b/src/crypto/keypair/secp256k1.rs
@@ -120,15 +120,18 @@ mod tests {
 
     #[test]
     fn different_keys() {
+        const MESSAGE: &[u8] = b"Hello, world!";
+
         let (sk1, pk1) = super::generate_keypair();
         let (sk2, pk2) = super::generate_keypair();
 
         assert_ne!(sk1.as_bytes(), sk2.as_bytes());
         assert_ne!(pk1.as_bytes(), pk2.as_bytes());
 
-        let ciphertext = pk1.encrypt(b"Hello").expect("Encryption failed");
-        let decrypted = sk2.decrypt(&ciphertext).expect("Decryption failed");
-
-        assert_ne!(decrypted, b"Hello");
+        let ciphertext = pk1.encrypt(MESSAGE).expect("Encryption failed");
+        assert!(
+            sk2.decrypt(&ciphertext).is_err(),
+            "Decryption should fail with different keys"
+        );
     }
 }


### PR DESCRIPTION
- Replace incorrect assertion with proper error check
- Fix test to verify decryption fails with wrong key (reports error)
- Previously test incorrectly expected wrong decryption resultc