### PR TITLE
chore: add cargo dependency caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Cache Rust dependencies
+      id: cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Cache Rust dependencies
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ~/.cargo/bin
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
       with:
@@ -23,6 +35,7 @@ jobs:
 
     - name: Install tarpaulin
       run: cargo install cargo-tarpaulin
+      if: steps.cache.outputs.cache-hit != 'true'
 
     - name: Run tests and generate coverage
       run: cargo tarpaulin --out Lcov --output-dir ./coverage


### PR DESCRIPTION
- Cache cargo registry, git, bin directories and target folder
- Skip tarpaulin installation when cache is present
- Use specific version of actions/cache for stability