### PR TITLE
refactor: move peer registry to top-level crypto module

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,6 +1,7 @@
 pub mod dkg;
 pub mod keypair;
 pub mod keypair_;
+pub mod peer_registry;
 pub mod primitives;
 pub mod tss;
 pub mod vrf;

--- a/src/crypto/dkg/joint_feldman.rs
+++ b/src/crypto/dkg/joint_feldman.rs
@@ -6,18 +6,15 @@ use crate::{
             joint_feldman::{
                 collector::{event, Collector},
                 distributor::Distributor,
-                peer_registry::PeerRegistry,
             },
             Dkg_, GenerateResult,
-        },
-        keypair::{PublicKey, SecretKey},
-        primitives::{
+        }, keypair::{PublicKey, SecretKey}, peer_registry::PeerRegistry, primitives::{
             algebra::{self, Point, Scalar},
             vss::{
                 decrypted_share::{self},
                 Vss,
             },
-        },
+        }
     },
     network::transport::Transport,
 };
@@ -25,7 +22,6 @@ use crate::{
 mod collector;
 mod config;
 mod distributor;
-mod peer_registry;
 
 pub use config::Config;
 

--- a/src/crypto/dkg/joint_feldman/collector.rs
+++ b/src/crypto/dkg/joint_feldman/collector.rs
@@ -2,13 +2,14 @@ use std::{collections::VecDeque, sync::Arc};
 
 use tokio::sync::{mpsc, oneshot};
 
+use crate::crypto::peer_registry::PeerRegistry;
 use crate::crypto::primitives::algebra::Point;
 use crate::crypto::{
     dkg::joint_feldman::collector::event::ActionNeeded, primitives::vss::DecryptedShares,
 };
 use crate::{
     crypto::{
-        dkg::joint_feldman::{collector::context::Context, peer_registry::PeerRegistry},
+        dkg::joint_feldman::collector::context::Context,
         keypair::{self, SecretKey},
         primitives::algebra::{self},
     },

--- a/src/crypto/dkg/joint_feldman/collector/context.rs
+++ b/src/crypto/dkg/joint_feldman/collector/context.rs
@@ -3,11 +3,9 @@ use std::sync::Arc;
 use dashmap::{mapref::one::RefMut, DashMap, DashSet};
 
 use crate::crypto::{
-    dkg::joint_feldman::{
-        collector::event::{self, ActionNeeded, Event},
-        peer_registry::PeerRegistry,
-    },
+    dkg::joint_feldman::collector::event::{self, ActionNeeded, Event},
     keypair::SecretKey,
+    peer_registry::PeerRegistry,
     primitives::{
         algebra::{self, Point},
         vss::{

--- a/src/crypto/dkg/joint_feldman/collector/event.rs
+++ b/src/crypto/dkg/joint_feldman/collector/event.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::crypto::{
-    dkg::joint_feldman::peer_registry::PeerRegistry,
     keypair::{self, PublicKey, SecretKey},
+    peer_registry::PeerRegistry,
     primitives::{
         algebra::{self, Point, Scalar},
         vss::{
@@ -462,11 +462,9 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use crate::crypto::{
-        dkg::joint_feldman::{
-            event::{ActionNeeded, Event, Output, Status},
-            peer_registry::PeerRegistry,
-        },
+        dkg::joint_feldman::event::{ActionNeeded, Event, Output, Status},
         keypair::{self, PublicKey, SecretKey},
+        peer_registry::PeerRegistry,
         primitives::{
             algebra::{Point, Scheme},
             vss::{DecryptedShares, EncryptedShares, Vss},

--- a/src/crypto/dkg/joint_feldman/distributor.rs
+++ b/src/crypto/dkg/joint_feldman/distributor.rs
@@ -2,15 +2,13 @@ use std::sync::Arc;
 
 use crate::{
     crypto::{
-        dkg::joint_feldman::peer_registry::PeerRegistry,
-        keypair,
-        primitives::{
+        keypair, peer_registry::PeerRegistry, primitives::{
             algebra::Point,
             vss::{
                 decrypted_share::DecryptedShares,
                 encrypted_share::{self, EncryptedShares},
             },
-        },
+        }
     },
     network::transport::{libp2p_transport::protocols::gossipsub, Transport},
 };
@@ -81,9 +79,7 @@ mod tests {
 
     use crate::{
         crypto::{
-            dkg::joint_feldman::{distributor::Distributor, peer_registry::PeerRegistry},
-            keypair,
-            primitives::{algebra::Scheme, vss::Vss},
+            dkg::joint_feldman::distributor::Distributor, keypair, peer_registry::PeerRegistry, primitives::{algebra::Scheme, vss::Vss}
         },
         network::transport::MockTransport,
         MockError,

--- a/src/crypto/peer_registry.rs
+++ b/src/crypto/peer_registry.rs
@@ -178,8 +178,8 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::crypto::{
-        dkg::joint_feldman::peer_registry::{PeerRegistry, MAX_PEERS},
         keypair::{self, PublicKey},
+        peer_registry::{PeerRegistry, MAX_PEERS},
     };
 
     const NUM_PEERS: usize = 3;


### PR DESCRIPTION
- Relocate PeerRegistry from dkg/joint_feldman to crypto directory
- Update all import references across affected files
- Make PeerRegistry available as a shared component across crypto modules