### PR TITLE
feat: implement committee public key storage with Kademlia

### DIFF
--- a/src/network/transport.rs
+++ b/src/network/transport.rs
@@ -37,7 +37,12 @@ pub trait Transport: Send + Sync {
         payload: gossipsub::Payload,
     ) -> Result<libp2p::gossipsub::MessageId, Self::Error>;
     async fn request(&self, peer_id: &libp2p::PeerId, request: Request);
-    async fn put(&self, payload: kad::Payload, signature: Signature) -> Result<(), Self::Error>;
+    async fn put(
+        &self,
+        key: kad::Key,
+        payload: kad::Payload,
+        signature: Signature,
+    ) -> Result<(), Self::Error>;
     async fn get(&self, key: kad::Key) -> Result<Option<kad::Payload>, Self::Error>;
     fn self_peer(&self) -> libp2p::PeerId;
     fn keypair(&self) -> &libp2p::identity::Keypair;

--- a/src/network/transport/libp2p_transport.rs
+++ b/src/network/transport/libp2p_transport.rs
@@ -260,8 +260,11 @@ impl Transport for Libp2pTransport {
         self.request_response.request(peer_id, request).await;
     }
 
-    async fn put(&self, payload: kad::Payload, signature: Signature) -> Result<()> {
-        self.kad.put(payload, signature).await.map_err(Error::from)
+    async fn put(&self, key: kad::Key, payload: kad::Payload, signature: Signature) -> Result<()> {
+        self.kad
+            .put(key, payload, signature)
+            .await
+            .map_err(Error::from)
     }
 
     async fn get(&self, key: kad::Key) -> Result<Option<kad::Payload>> {

--- a/src/network/transport/libp2p_transport/protocols/kad.rs
+++ b/src/network/transport/libp2p_transport/protocols/kad.rs
@@ -154,9 +154,9 @@ impl Kad {
         }
     }
 
-    pub async fn put(&self, key: Key, payload: Payload, signture: Signature) -> Result<()> {
+    pub async fn put(&self, key: Key, payload: Payload, signature: Signature) -> Result<()> {
         let key = key.to_storage_key()?;
-        let record_value = Message::new(payload, signture).to_vec()?;
+        let record_value = Message::new(payload, signature).to_vec()?;
         let record = libp2p::kad::Record::new(key, record_value);
 
         let mut swarm = self.swarm.lock().await;

--- a/src/network/transport/libp2p_transport/protocols/kad.rs
+++ b/src/network/transport/libp2p_transport/protocols/kad.rs
@@ -154,10 +154,10 @@ impl Kad {
         }
     }
 
-    pub async fn put(&self, payload: Payload, signture: Signature) -> Result<()> {
-        let record_key = Self::generate_key(&payload)?;
+    pub async fn put(&self, key: Key, payload: Payload, signture: Signature) -> Result<()> {
+        let key = key.to_storage_key()?;
         let record_value = Message::new(payload, signture).to_vec()?;
-        let record = libp2p::kad::Record::new(record_key, record_value);
+        let record = libp2p::kad::Record::new(key, record_value);
 
         let mut swarm = self.swarm.lock().await;
         let query_id = swarm
@@ -169,15 +169,6 @@ impl Kad {
         self.waiting_put_queries.insert(query_id, tx);
 
         tokio::time::timeout(self.config.wait_for_kad_result_timeout, rx).await??
-    }
-
-    fn generate_key(payload: &Payload) -> Result<libp2p::kad::RecordKey> {
-        let key = match payload {
-            Payload::PeerInfo { peer_id, .. } => Key::PeerInfo(*peer_id),
-            _ => return Err(Error::InvalidPayloadType),
-        };
-
-        Ok(key.to_storage_key()?)
     }
 
     pub async fn get(&self, key: Key) -> Result<Option<Payload>> {

--- a/src/network/transport/libp2p_transport/protocols/kad/key.rs
+++ b/src/network/transport/libp2p_transport/protocols/kad/key.rs
@@ -1,3 +1,4 @@
+use libp2p::kad::RecordKey;
 use serde::{Deserialize, Serialize};
 
 type Result<T> = std::result::Result<T, Error>;
@@ -12,7 +13,7 @@ pub enum Error {
 #[derive(Debug)]
 #[derive(Serialize, Deserialize)]
 pub enum Key {
-    PeerInfo(libp2p::PeerId),
+    CommitteePubKey(u64),
 }
 
 impl Key {
@@ -21,7 +22,15 @@ impl Key {
     }
 
     pub fn to_storage_key(&self) -> Result<libp2p::kad::RecordKey> {
-        let key_bytes = self.to_vec()?;
+        self.try_into()
+    }
+}
+
+impl TryFrom<&Key> for RecordKey {
+    type Error = Error;
+
+    fn try_from(key: &Key) -> std::result::Result<Self, Self::Error> {
+        let key_bytes = key.to_vec()?;
         Ok(libp2p::kad::RecordKey::new(&key_bytes))
     }
 }

--- a/src/network/transport/libp2p_transport/protocols/kad/payload.rs
+++ b/src/network/transport/libp2p_transport/protocols/kad/payload.rs
@@ -1,7 +1,8 @@
 use bincode::{config, error::EncodeError, serde::encode_to_vec};
-use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::crypto::primitives::algebra::Point;
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -20,7 +21,7 @@ pub enum Error {
 #[derive(Eq, PartialEq)]
 #[derive(Serialize, Deserialize)]
 pub enum Payload {
-    PeerInfo { peer_id: PeerId, pub_key: Vec<u8> },
+    CommitteePubKey(Point),
     // For testing
     Raw(Vec<u8>),
 }


### PR DESCRIPTION
- Add storage_new_public_key method to store committee public keys
- Implement sign_kad_message for signing Kademlia payloads
- Update Transport trait to support key-based Kademlia operations
- Add CommitteePubKey to Kad key and payload types