### PR TITLE
chore: switch CI workflow to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-and-coverage:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Replace ubuntu-latest with self-hosted runner for CI jobs
- Optimize CI pipeline execution by using local infrastructure