### PR TITLE
chore: ignore .github/instructions directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.github/instructions


### PR DESCRIPTION
- Add .github/instructions to .gitignore to prevent committing internal project instructions