### PR TITLE
refactor: remove Result from Serializable::to_writer

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -76,8 +76,7 @@ impl PublicKey {
         match self {
             PublicKey::Secp256k1(pk) => {
                 // pk size is 32, so don't need to hash it
-                Multihash::wrap(0, &pk.to_vec().expect("PublicKey should be serializable"))
-                    .expect("Failed to wrap PublicKey into Multihash")
+                Multihash::wrap(0, &pk.to_vec()).expect("Failed to wrap PublicKey into Multihash")
             }
         }
     }
@@ -128,10 +127,8 @@ impl SecretKey {
     pub fn to_libp2p_key(&self) -> libp2p::identity::Keypair {
         match self {
             SecretKey::Secp256k1(sk) => {
-                let sk = libp2p::identity::secp256k1::SecretKey::try_from_bytes(
-                    sk.to_vec().expect("SecretKey should be serializable"),
-                )
-                .expect("Failed to convert SecretKey to libp2p Secp256k1 SecretKey");
+                let sk = libp2p::identity::secp256k1::SecretKey::try_from_bytes(sk.to_vec())
+                    .expect("Failed to convert SecretKey to libp2p Secp256k1 SecretKey");
                 libp2p::identity::secp256k1::Keypair::from(sk).into()
             }
         }
@@ -172,7 +169,7 @@ impl Serializable for Suite {
         }
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         match self {
             Suite::Secp256k1 => 0u8.to_writer(writer),
         }
@@ -201,8 +198,8 @@ impl Serializable for PublicKey {
         }
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.suite().to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.suite().to_writer(writer);
 
         match self {
             PublicKey::Secp256k1(pk) => pk.to_writer(writer),
@@ -228,8 +225,8 @@ impl Serializable for SecretKey {
         }
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.suite().to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.suite().to_writer(writer);
 
         match self {
             SecretKey::Secp256k1(sk) => sk.to_writer(writer),
@@ -261,8 +258,8 @@ impl Serializable for Signature {
         }
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.suite().to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.suite().to_writer(writer);
 
         match self {
             Signature::Secp256k1(sig) => sig.to_writer(writer),
@@ -294,8 +291,8 @@ impl Serializable for Proof {
         }
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.suite().to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.suite().to_writer(writer);
 
         match self {
             Proof::Secp256k1(proof) => proof.to_writer(writer),

--- a/src/crypto/ec/public_key.rs
+++ b/src/crypto/ec/public_key.rs
@@ -16,8 +16,9 @@ impl<C: SWCurveConfig> Serializable for Affine<C> {
         Self::deserialize_compressed(reader).map_err(Error::from)
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
-        self.serialize_compressed(writer).map_err(Error::from)
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.serialize_compressed(writer)
+            .expect("Failed to serialize Affine point");
     }
 }
 

--- a/src/crypto/ec/secret_key.rs
+++ b/src/crypto/ec/secret_key.rs
@@ -40,10 +40,10 @@ impl<C: SWCurveConfig> Serializable for SecretKey<C> {
         Ok(Self::new(sk))
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), Error> {
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         self.sk
             .serialize_compressed(writer)
-            .map_err(|e| Error(e.to_string()))
+            .expect("Failed to serialize SecretKey");
     }
 }
 

--- a/src/crypto/ec/signature.rs
+++ b/src/crypto/ec/signature.rs
@@ -42,11 +42,13 @@ where
         Ok(Self { r, s })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), SerializableError> {
-        self.r.serialize_compressed(writer.by_ref())?;
-        self.s.serialize_compressed(writer.by_ref())?;
-
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.r
+            .serialize_compressed(writer.by_ref())
+            .expect("Failed to serialize r");
+        self.s
+            .serialize_compressed(writer.by_ref())
+            .expect("Failed to serialize s");
     }
 }
 

--- a/src/crypto/ec/vrf.rs
+++ b/src/crypto/ec/vrf.rs
@@ -67,12 +67,16 @@ where
         Ok(Self { gamma, c, s })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), SerializableError> {
-        self.gamma.serialize_compressed(writer.by_ref())?;
-        self.c.serialize_compressed(writer.by_ref())?;
-        self.s.serialize_compressed(writer.by_ref())?;
-
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.gamma
+            .serialize_compressed(writer.by_ref())
+            .expect("Failed to serialize gamma");
+        self.c
+            .serialize_compressed(writer.by_ref())
+            .expect("Failed to serialize c");
+        self.s
+            .serialize_compressed(writer.by_ref())
+            .expect("Failed to serialize s");
     }
 }
 

--- a/src/network/gossipsub/network.rs
+++ b/src/network/gossipsub/network.rs
@@ -13,7 +13,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
 #[derive(thiserror::Error)]
-pub(super) enum Error {
+pub enum Error {
     #[error("{0}")]
     Subscribe(#[from] SubscriptionError),
 

--- a/src/network/storage/local_one.rs
+++ b/src/network/storage/local_one.rs
@@ -29,7 +29,7 @@ impl Storage {
     where
         T: Serializable,
     {
-        self.records.insert(key, value.to_vec()?);
+        self.records.insert(key, value.to_vec());
         Ok(())
     }
 
@@ -49,7 +49,7 @@ impl Storage {
     {
         self.records
             .get(key)
-            .map(|record| T::from_slice(&record.value()).map_err(Error::from))
+            .map(|record| T::from_slice(record.value()).map_err(Error::from))
             .transpose()
     }
 }

--- a/src/network/storage/network.rs
+++ b/src/network/storage/network.rs
@@ -144,7 +144,7 @@ impl Storage {
         T: Serializable + Sync + Send + 'static,
     {
         let key = RecordKey::new(&key.to_bytes());
-        let record = Record::new(key, value.to_vec()?);
+        let record = Record::new(key, value.to_vec());
 
         let mut swarm = self.swarm.lock().await;
         let query_id = swarm
@@ -177,7 +177,7 @@ impl Storage {
 
         for (hash, value) in items {
             let key = libp2p::kad::RecordKey::new(&hash.to_bytes());
-            let record = libp2p::kad::Record::new(key, value.to_vec()?);
+            let record = libp2p::kad::Record::new(key, value.to_vec());
             records.push(record);
         }
 

--- a/src/proposal.rs
+++ b/src/proposal.rs
@@ -57,9 +57,7 @@ pub struct Proposal {
 
 impl Payload {
     pub fn hash<H: Hasher>(&self) -> Multihash {
-        *self
-            .hash_cache
-            .get_or_init(|| H::hash(&self.to_vec().expect("Payload should be serializable")))
+        *self.hash_cache.get_or_init(|| H::hash(&self.to_vec()))
     }
 
     pub fn sign<H: Hasher>(&self, sk: &SecretKey) -> Signature {
@@ -91,10 +89,9 @@ impl Serializable for Diff {
         Ok(Self { from, to })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.from.to_writer(writer)?;
-        self.to.to_writer(writer)?;
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.from.to_writer(writer);
+        self.to.to_writer(writer);
     }
 }
 impl Serializable for Payload {
@@ -125,16 +122,14 @@ impl Serializable for Payload {
         })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.code.to_writer(writer)?;
-        self.parent_root.to_writer(writer)?;
-        self.diff.to_writer(writer)?;
-        self.total_stakes_diff.to_writer(writer)?;
-        self.proposer_pk.to_writer(writer)?;
-        self.proposer_data.to_writer(writer)?;
-        self.proposal_stakes.to_writer(writer)?;
-
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.code.to_writer(writer);
+        self.parent_root.to_writer(writer);
+        self.diff.to_writer(writer);
+        self.total_stakes_diff.to_writer(writer);
+        self.proposer_pk.to_writer(writer);
+        self.proposer_data.to_writer(writer);
+        self.proposal_stakes.to_writer(writer);
     }
 }
 
@@ -151,10 +146,9 @@ impl Serializable for Witness {
         Ok(Self { sig, proofs })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.sig.to_writer(writer)?;
-        self.proofs.to_writer(writer)?;
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.sig.to_writer(writer);
+        self.proofs.to_writer(writer);
     }
 }
 
@@ -172,10 +166,9 @@ impl Serializable for Proposal {
         })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.payload.to_writer(writer)?;
-        self.witness.to_writer(writer)?;
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.payload.to_writer(writer);
+        self.witness.to_writer(writer);
     }
 }
 
@@ -219,7 +212,7 @@ mod tests {
         let prop = setup();
         let payload = prop.payload.clone();
 
-        let enc = payload.to_vec().expect("Payload should be serializable");
+        let enc = payload.to_vec();
         let dec = Payload::from_slice(&enc).expect("Payload should be deserializable");
 
         assert_eq!(
@@ -233,7 +226,7 @@ mod tests {
         let prop = setup();
         let witness = prop.witness.clone();
 
-        let enc = witness.to_vec().expect("Witness should be serializable");
+        let enc = witness.to_vec();
         let dec = Witness::from_slice(&enc).expect("Witness should be deserializable");
 
         assert_eq!(
@@ -246,7 +239,7 @@ mod tests {
     fn proposal_serialization() {
         let prop = setup();
 
-        let enc = prop.to_vec().expect("Proposal should be serializable");
+        let enc = prop.to_vec();
         let dec = Proposal::from_slice(&enc).expect("Proposal should be deserializable");
 
         assert_eq!(prop, dec, "Deserialized proposal should match the original");

--- a/src/resident/record.rs
+++ b/src/resident/record.rs
@@ -31,19 +31,14 @@ impl Serializable for Record {
     }
 
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
-        let stakes = u32::from_reader(reader)?;
-        let data_length = usize::from_reader(reader)?;
-
-        let mut data = vec![0; data_length];
-        reader.read_exact(&mut data)?;
-
-        Ok(Record { stakes, data })
+        Ok(Record {
+            stakes: u32::from_reader(reader)?,
+            data: Vec::from_reader(reader)?,
+        })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.stakes.to_writer(writer)?;
-        self.data.len().to_writer(writer)?;
-        writer.write_all(&self.data)?;
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.stakes.to_writer(writer);
+        self.data.to_writer(writer);
     }
 }

--- a/src/traits/serializable.rs
+++ b/src/traits/serializable.rs
@@ -21,15 +21,15 @@ pub trait Serializable: Sized {
     fn serialized_size(&self) -> usize;
 
     fn from_reader<R: Read>(reader: &mut R) -> Result<Self, Error>;
-    fn to_writer<W: Write>(&self, writer: &mut W) -> Result<(), Error>;
+    fn to_writer<W: Write>(&self, writer: &mut W);
     fn from_slice(slice: &[u8]) -> Result<Self, Error> {
         let mut reader = slice;
         Self::from_reader(&mut reader)
     }
-    fn to_vec(&self) -> Result<Vec<u8>, Error> {
+    fn to_vec(&self) -> Vec<u8> {
         let mut writer = Vec::new();
-        self.to_writer(&mut writer)?;
-        Ok(writer)
+        self.to_writer(&mut writer);
+        writer
     }
 }
 

--- a/src/traits/serializable/b_tree_map.rs
+++ b/src/traits/serializable/b_tree_map.rs
@@ -28,14 +28,12 @@ where
         Ok(map)
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.len().to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
 
         for (key, value) in self {
-            key.to_writer(writer)?;
-            value.to_writer(writer)?;
+            key.to_writer(writer);
+            value.to_writer(writer);
         }
-
-        Ok(())
     }
 }

--- a/src/traits/serializable/b_tree_set.rs
+++ b/src/traits/serializable/b_tree_set.rs
@@ -22,22 +22,10 @@ where
         Ok(set)
     }
 
-    fn to_writer<W: std::io::Write>(
-        &self,
-        writer: &mut W,
-    ) -> Result<(), crate::traits::serializable::Error> {
-        self.len().to_writer(writer)?;
-
-        for value in self {
-            value.to_writer(writer)?;
-        }
-
-        Ok(())
-    }
-
-    fn to_vec(&self) -> Result<Vec<u8>, serializable::Error> {
-        let mut writer = Vec::new();
-        self.to_writer(&mut writer)?;
-        Ok(writer)
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
+        self.iter().for_each(|value| {
+            value.to_writer(writer);
+        });
     }
 }

--- a/src/traits/serializable/box_.rs
+++ b/src/traits/serializable/box_.rs
@@ -13,7 +13,7 @@ where
         Ok(Box::new(inner))
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         self.as_ref().to_writer(writer)
     }
 }

--- a/src/traits/serializable/hash_map.rs
+++ b/src/traits/serializable/hash_map.rs
@@ -33,14 +33,12 @@ where
         Ok(map)
     }
 
-    fn to_writer<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        self.len().to_writer(writer)?;
+    fn to_writer<W: Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
 
         for (key, value) in self {
-            key.to_writer(writer)?;
-            value.to_writer(writer)?;
+            key.to_writer(writer);
+            value.to_writer(writer);
         }
-
-        Ok(())
     }
 }

--- a/src/traits/serializable/message_id.rs
+++ b/src/traits/serializable/message_id.rs
@@ -8,10 +8,10 @@ impl Serializable for MessageId {
     }
 
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
-        Ok(MessageId(Vec::<u8>::from_reader(reader)?))
+        Ok(MessageId(Vec::from_reader(reader)?))
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         self.0.to_writer(writer)
     }
 }

--- a/src/traits/serializable/multiaddr.rs
+++ b/src/traits/serializable/multiaddr.rs
@@ -16,13 +16,13 @@ impl Serializable for Multiaddr {
         Multiaddr::try_from(bytes).map_err(|e| serializable::Error(e.to_string()))
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         let bytes = self.to_vec();
         let size = bytes.len();
 
-        size.to_writer(writer)?;
-        writer.write_all(&bytes)?;
-
-        Ok(())
+        size.to_writer(writer);
+        writer
+            .write_all(&bytes)
+            .expect("Failed to write Multiaddr bytes");
     }
 }

--- a/src/traits/serializable/multihash.rs
+++ b/src/traits/serializable/multihash.rs
@@ -20,11 +20,12 @@ impl Serializable for Multihash {
         Ok(Multihash::wrap(code, &digest)?)
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.code().to_writer(writer)?;
-        self.size().to_writer(writer)?;
-        writer.write_all(self.digest())?;
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.code().to_writer(writer);
+        self.size().to_writer(writer);
+        writer
+            .write_all(self.digest())
+            .expect("Failed to write digest");
     }
 }
 

--- a/src/traits/serializable/numeric.rs
+++ b/src/traits/serializable/numeric.rs
@@ -16,9 +16,8 @@ macro_rules! impl_serializable_for_numeric {
                     Ok(<$type>::from_ne_bytes(buffer))
                 }
 
-                fn to_writer<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-                    writer.write_all(&self.to_ne_bytes())?;
-                    Ok(())
+                fn to_writer<W: Write>(&self, writer: &mut W) {
+                    writer.write_all(&self.to_ne_bytes()).expect("Failed to write numeric value");
                 }
             }
 

--- a/src/traits/serializable/option.rs
+++ b/src/traits/serializable/option.rs
@@ -21,15 +21,14 @@ where
         }
     }
 
-    fn to_writer<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+    fn to_writer<W: Write>(&self, writer: &mut W) {
         match self {
             Some(value) => {
-                1u8.to_writer(writer)?;
-                value.to_writer(writer)?;
+                1u8.to_writer(writer);
+                value.to_writer(writer);
             }
-            None => 0u8.to_writer(writer)?,
+            None => 0u8.to_writer(writer),
         }
-        Ok(())
     }
 }
 

--- a/src/traits/serializable/peer_id.rs
+++ b/src/traits/serializable/peer_id.rs
@@ -13,7 +13,7 @@ impl Serializable for PeerId {
             .map_err(|_| serializable::Error("Failed to convert Multihash to PeerId".to_string()))
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         self.as_ref().to_writer(writer)
     }
 }

--- a/src/traits/serializable/string.rs
+++ b/src/traits/serializable/string.rs
@@ -12,9 +12,8 @@ impl Serializable for String {
         String::from_utf8(buffer).map_err(|e| serializable::Error(e.to_string()))
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.len().to_writer(writer)?;
-        writer.write_all(self.as_bytes())?;
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
+        writer.write_all(self.as_bytes());
     }
 }

--- a/src/traits/serializable/tuple.rs
+++ b/src/traits/serializable/tuple.rs
@@ -15,10 +15,9 @@ where
         Ok((a, b))
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.0.to_writer(writer)?;
-        self.1.to_writer(writer)?;
-        Ok(())
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.0.to_writer(writer);
+        self.1.to_writer(writer);
     }
 }
 

--- a/src/traits/serializable/vec.rs
+++ b/src/traits/serializable/vec.rs
@@ -21,11 +21,10 @@ where
         Ok(vec)
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        self.len().to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
         for item in self {
-            item.to_writer(writer)?;
+            item.to_writer(writer);
         }
-        Ok(())
     }
 }

--- a/src/utils/mpt.rs
+++ b/src/utils/mpt.rs
@@ -226,7 +226,7 @@ impl<H: Hasher, S: Storage> MerklePatriciaTrie<H, S> {
             Node::Short(ref mut short) => {
                 Self::commit_node(&mut short.val, false, pending);
 
-                let bytes = short.to_vec().expect("Failed to serialize short node");
+                let bytes = short.to_vec();
 
                 if bytes.len() < 32 && !force {
                     return;
@@ -245,7 +245,7 @@ impl<H: Hasher, S: Storage> MerklePatriciaTrie<H, S> {
                     }
                 });
 
-                let bytes = full.to_vec().expect("Failed to serialize full node");
+                let bytes = full.to_vec();
 
                 if bytes.len() < 32 && !force {
                     return;
@@ -298,7 +298,7 @@ impl<H: Hasher, S: Storage> MerklePatriciaTrie<H, S> {
         nodes.push(self.root.clone());
 
         for n in nodes.iter() {
-            let enc = n.to_vec().expect("Failed to serialize node");
+            let enc = n.to_vec();
             let hash = n.cache().cloned().unwrap_or(H::hash(&enc));
             proof_db.insert(hash, enc);
         }
@@ -310,9 +310,11 @@ impl<H: Hasher, S: Storage> MerklePatriciaTrie<H, S> {
         let key_vec = slice_to_hex(key);
         let mut key = key_vec.as_slice();
 
-        let mut expected_hash = self.root.cache().cloned().unwrap_or_else(|| {
-            H::hash(&self.root.to_vec().expect("Failed to serialize root node"))
-        });
+        let mut expected_hash = self
+            .root
+            .cache()
+            .cloned()
+            .unwrap_or_else(|| H::hash(&self.root.to_vec()));
 
         loop {
             let cur = proof_db.get(&expected_hash)?;

--- a/src/utils/mpt/node.rs
+++ b/src/utils/mpt/node.rs
@@ -201,12 +201,11 @@ impl Serializable for Full {
         })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        FULL_TAG.to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        FULL_TAG.to_writer(writer);
         self.children
             .iter()
-            .try_for_each(|child| child.to_writer(writer))?;
-        Ok(())
+            .for_each(|child| child.to_writer(writer));
     }
 }
 
@@ -229,18 +228,16 @@ impl Serializable for Short {
         })
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
-        SHORT_TAG.to_writer(writer)?;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        SHORT_TAG.to_writer(writer);
 
         let vec = hex_to_vec(&self.key);
         let len = vec.len() as u8;
 
-        len.to_writer(writer)?;
-        writer.write_all(&vec)?;
+        len.to_writer(writer);
+        writer.write_all(&vec).expect("Failed to write key");
 
-        self.val.to_writer(writer)?;
-
-        Ok(())
+        self.val.to_writer(writer);
     }
 }
 
@@ -274,27 +271,25 @@ impl Serializable for Node {
         }
     }
 
-    fn to_writer<W: std::io::Write>(&self, writer: &mut W) -> Result<(), serializable::Error> {
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         match self {
-            Node::Empty => EMPTY_TAG.to_writer(writer)?,
+            Node::Empty => EMPTY_TAG.to_writer(writer),
             Node::Full(full) => {
                 // full will write its own tag
-                full.to_writer(writer)?;
+                full.to_writer(writer);
             }
             Node::Short(short) => {
                 // short will write its own tag
-                short.to_writer(writer)?;
+                short.to_writer(writer);
             }
             Node::Hash(hash) => {
-                HASH_TAG.to_writer(writer)?;
-                hash.to_writer(writer)?;
+                HASH_TAG.to_writer(writer);
+                hash.to_writer(writer);
             }
             Node::Value(value) => {
-                VALUE_TAG.to_writer(writer)?;
-                value.to_writer(writer)?;
+                VALUE_TAG.to_writer(writer);
+                value.to_writer(writer);
             }
         }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
- Change Serializable::to_writer to return nothing and panic on error
- Update all implementations and usages to match new signature
- Remove error handling from to_vec and related serialization code
- Improves ergonomics for serialization where errors are not expected