### PR TITLE
refactor: remove ConstantSize trait and serialized_size methods

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -5,7 +5,7 @@ use crate::{
         vrf::{Proof as _, Prover as _, VerifyProof},
         SecretKey as _, Signer as _, VerifiySignature,
     },
-    traits::{serializable, ConstantSize, Serializable},
+    traits::{serializable, Serializable},
 };
 
 mod ec;
@@ -158,10 +158,6 @@ impl Proof {
 }
 
 impl Serializable for Suite {
-    fn serialized_size(&self) -> usize {
-        u8::SIZE
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         match u8::from_reader(reader)? {
             0 => Ok(Suite::Secp256k1),
@@ -176,18 +172,11 @@ impl Serializable for Suite {
     }
 }
 
-impl ConstantSize for Suite {
-    const SIZE: usize = 1;
-}
+// impl ConstantSize for Suite {
+//     const SIZE: usize = 1;
+// }
 
 impl Serializable for PublicKey {
-    fn serialized_size(&self) -> usize {
-        Suite::SIZE
-            + match self {
-                PublicKey::Secp256k1(_) => short_weierstrass::Affine::<ark_secp256k1::Config>::SIZE,
-            }
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let suite = Suite::from_reader(reader)?;
 
@@ -208,13 +197,6 @@ impl Serializable for PublicKey {
 }
 
 impl Serializable for SecretKey {
-    fn serialized_size(&self) -> usize {
-        Suite::SIZE
-            + match self {
-                SecretKey::Secp256k1(_) => ec::SecretKey::<ark_secp256k1::Config>::SIZE,
-            }
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let suite = Suite::from_reader(reader)?;
 
@@ -235,18 +217,6 @@ impl Serializable for SecretKey {
 }
 
 impl Serializable for Signature {
-    fn serialized_size(&self) -> usize {
-        Suite::SIZE
-            + match self {
-                Signature::Secp256k1(_) => {
-                    ec::Signature::<
-                        short_weierstrass::Affine<ark_secp256k1::Config>,
-                        ark_secp256k1::Fr,
-                    >::SIZE
-                }
-            }
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let suite = Suite::from_reader(reader)?;
 
@@ -268,18 +238,6 @@ impl Serializable for Signature {
 }
 
 impl Serializable for Proof {
-    fn serialized_size(&self) -> usize {
-        Suite::SIZE
-            + match self {
-                Proof::Secp256k1(_) => {
-                    ec::vrf::Proof::<
-                        short_weierstrass::Affine<ark_secp256k1::Config>,
-                        ark_secp256k1::Fr,
-                    >::SIZE
-                }
-            }
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let suite = Suite::from_reader(reader)?;
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -172,10 +172,6 @@ impl Serializable for Suite {
     }
 }
 
-// impl ConstantSize for Suite {
-//     const SIZE: usize = 1;
-// }
-
 impl Serializable for PublicKey {
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let suite = Suite::from_reader(reader)?;

--- a/src/crypto/ec/public_key.rs
+++ b/src/crypto/ec/public_key.rs
@@ -1,17 +1,12 @@
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
-use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::{
     crypto::traits::PublicKey,
-    traits::serializable::{ConstantSize, Error, Serializable},
+    traits::serializable::{Error, Serializable},
 };
 
 impl<C: SWCurveConfig> Serializable for Affine<C> {
-    fn serialized_size(&self) -> usize {
-        self.compressed_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
         Self::deserialize_compressed(reader).map_err(Error::from)
     }
@@ -20,10 +15,6 @@ impl<C: SWCurveConfig> Serializable for Affine<C> {
         self.serialize_compressed(writer)
             .expect("Failed to serialize Affine point");
     }
-}
-
-impl<C: SWCurveConfig> ConstantSize for Affine<C> {
-    const SIZE: usize = 1 + C::ScalarField::MODULUS_BIT_SIZE as usize / 8usize;
 }
 
 impl<C: SWCurveConfig> PublicKey for Affine<C> {}

--- a/src/crypto/ec/secret_key.rs
+++ b/src/crypto/ec/secret_key.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 
 use crate::{
     crypto::traits,
-    traits::serializable::{ConstantSize, Error, Serializable},
+    traits::serializable::{Error, Serializable},
 };
 
 #[derive(Derivative)]
@@ -30,10 +30,6 @@ impl<C: SWCurveConfig> SecretKey<C> {
 }
 
 impl<C: SWCurveConfig> Serializable for SecretKey<C> {
-    fn serialized_size(&self) -> usize {
-        self.sk.compressed_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, Error> {
         let sk =
             C::ScalarField::deserialize_compressed(reader).map_err(|e| Error(e.to_string()))?;
@@ -45,10 +41,6 @@ impl<C: SWCurveConfig> Serializable for SecretKey<C> {
             .serialize_compressed(writer)
             .expect("Failed to serialize SecretKey");
     }
-}
-
-impl<C: SWCurveConfig> ConstantSize for SecretKey<C> {
-    const SIZE: usize = C::ScalarField::MODULUS_BIT_SIZE as usize / 8usize;
 }
 
 impl<C: SWCurveConfig> traits::SecretKey for SecretKey<C> {

--- a/src/crypto/ec/signature.rs
+++ b/src/crypto/ec/signature.rs
@@ -14,7 +14,7 @@ use crate::{
         traits::{self, SecretKey as _},
         Hasher,
     },
-    traits::serializable::{ConstantSize, Error as SerializableError, Serializable},
+    traits::serializable::{Error as SerializableError, Serializable},
 };
 
 #[derive(Clone)]
@@ -31,10 +31,6 @@ where
     P: CanonicalSerialize + CanonicalDeserialize,
     S: CanonicalSerialize + CanonicalDeserialize,
 {
-    fn serialized_size(&self) -> usize {
-        self.r.compressed_size() + self.s.compressed_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, SerializableError> {
         let r = P::deserialize_compressed(reader.by_ref())?;
         let s = S::deserialize_compressed(reader.by_ref())?;
@@ -50,10 +46,6 @@ where
             .serialize_compressed(writer.by_ref())
             .expect("Failed to serialize s");
     }
-}
-
-impl<C: SWCurveConfig + HasherConfig> ConstantSize for Signature<Affine<C>, C::ScalarField> {
-    const SIZE: usize = Affine::<C>::SIZE + C::ScalarField::MODULUS_BIT_SIZE as usize / 8usize;
 }
 
 impl<C: SWCurveConfig + HasherConfig> traits::Signature for Signature<Affine<C>, C::ScalarField> {}

--- a/src/crypto/ec/vrf.rs
+++ b/src/crypto/ec/vrf.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use ark_ec::{short_weierstrass::Affine, AffineRepr, CurveGroup};
-use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::{
@@ -17,7 +16,7 @@ use crate::{
             SecretKey as _,
         },
     },
-    traits::serializable::{ConstantSize, Error as SerializableError, Serializable},
+    traits::serializable::{Error as SerializableError, Serializable},
 };
 
 mod challenge_generator;
@@ -55,10 +54,6 @@ where
     P: CanonicalSerialize + CanonicalDeserialize,
     S: CanonicalSerialize + CanonicalDeserialize,
 {
-    fn serialized_size(&self) -> usize {
-        self.gamma.compressed_size() + self.c.compressed_size() + self.s.compressed_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, SerializableError> {
         let gamma = P::deserialize_compressed(reader.by_ref())?;
         let c = S::deserialize_compressed(reader.by_ref())?;
@@ -78,14 +73,6 @@ where
             .serialize_compressed(writer.by_ref())
             .expect("Failed to serialize s");
     }
-}
-
-impl<C> ConstantSize for Proof<Affine<C>, C::ScalarField>
-where
-    C: hash_to_curve::Config,
-{
-    const SIZE: usize =
-        Affine::<C>::SIZE + 2 * (C::ScalarField::MODULUS_BIT_SIZE as usize / 8usize);
 }
 
 impl<C> Prover for SecretKey<C>

--- a/src/crypto/traits/public_key.rs
+++ b/src/crypto/traits/public_key.rs
@@ -1,8 +1,5 @@
 use std::{fmt::Debug, hash::Hash};
 
-use crate::traits::serializable::{ConstantSize, Serializable};
+use crate::traits::serializable::Serializable;
 
-pub trait PublicKey:
-    Clone + Debug + Eq + Hash + Serializable + ConstantSize + Sync + Send + 'static
-{
-}
+pub trait PublicKey: Clone + Debug + Eq + Hash + Serializable + Sync + Send + 'static {}

--- a/src/crypto/traits/secret_key.rs
+++ b/src/crypto/traits/secret_key.rs
@@ -1,10 +1,8 @@
 use std::fmt::Debug;
 
-use crate::traits::serializable::{ConstantSize, Serializable};
+use crate::traits::serializable::Serializable;
 
-pub trait SecretKey:
-    Clone + Debug + Eq + Serializable + ConstantSize + Sync + Send + 'static
-{
+pub trait SecretKey: Clone + Debug + Eq + Serializable + Sync + Send + 'static {
     type PublicKey;
 
     fn random() -> Self;

--- a/src/crypto/traits/signature.rs
+++ b/src/crypto/traits/signature.rs
@@ -2,13 +2,10 @@ use std::fmt::Debug;
 
 use crate::{
     crypto::traits::{secret_key::SecretKey, PublicKey},
-    traits::serializable::{ConstantSize, Serializable},
+    traits::serializable::Serializable,
 };
 
-pub trait Signature:
-    Clone + Debug + Eq + Serializable + ConstantSize + Sync + Send + 'static
-{
-}
+pub trait Signature: Clone + Debug + Eq + Serializable + Sync + Send + 'static {}
 
 pub trait Signer: SecretKey {
     type Signature: Signature;

--- a/src/crypto/traits/vrf.rs
+++ b/src/crypto/traits/vrf.rs
@@ -2,10 +2,10 @@ use std::fmt::Debug;
 
 use crate::{
     crypto::traits::{hasher::Multihash, secret_key::SecretKey, PublicKey},
-    traits::serializable::{ConstantSize, Serializable},
+    traits::serializable::Serializable,
 };
 
-pub trait Proof: Clone + Debug + Eq + Serializable + ConstantSize + Sync + Send + 'static {
+pub trait Proof: Clone + Debug + Eq + Serializable + Sync + Send + 'static {
     fn proof_to_hash(&self) -> Multihash;
 }
 

--- a/src/proposal.rs
+++ b/src/proposal.rs
@@ -79,10 +79,6 @@ impl Proposal {
 }
 
 impl Serializable for Diff {
-    fn serialized_size(&self) -> usize {
-        self.from.serialized_size() + self.to.serialized_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let from = resident::Record::from_reader(reader)?;
         let to = resident::Record::from_reader(reader)?;
@@ -95,12 +91,6 @@ impl Serializable for Diff {
     }
 }
 impl Serializable for Payload {
-    fn serialized_size(&self) -> usize {
-        unimplemented!(
-            "Calculate size will very slowly, please just use Vec::new() without capacity"
-        );
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let code = u8::from_reader(reader)?;
         let parent_root = Multihash::from_reader(reader)?;
@@ -134,12 +124,6 @@ impl Serializable for Payload {
 }
 
 impl Serializable for Witness {
-    fn serialized_size(&self) -> usize {
-        unimplemented!(
-            "Calculate size will very slowly, please just use Vec::new() without capacity"
-        );
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let sig = Signature::from_reader(reader)?;
         let proofs = ProofDb::from_reader(reader)?;
@@ -153,12 +137,6 @@ impl Serializable for Witness {
 }
 
 impl Serializable for Proposal {
-    fn serialized_size(&self) -> usize {
-        unimplemented!(
-            "Calculate size will very slowly, please just use Vec::new() without capacity"
-        );
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         Ok(Self {
             payload: Payload::from_reader(reader)?,

--- a/src/resident/record.rs
+++ b/src/resident/record.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::traits::{serializable, ConstantSize, Serializable};
+use crate::traits::{serializable, Serializable};
 
 #[derive(Debug)]
 #[derive(thiserror::Error)]
@@ -26,10 +26,6 @@ impl Record {
 }
 
 impl Serializable for Record {
-    fn serialized_size(&self) -> usize {
-        u32::SIZE + usize::SIZE + self.data.len()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         Ok(Record {
             stakes: u32::from_reader(reader)?,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,4 +2,4 @@
 
 pub mod serializable;
 
-pub use serializable::{ConstantSize, Serializable};
+pub use serializable::Serializable;

--- a/src/traits/serializable.rs
+++ b/src/traits/serializable.rs
@@ -18,8 +18,6 @@ pub mod vec;
 pub struct Error(pub String);
 
 pub trait Serializable: Sized {
-    fn serialized_size(&self) -> usize;
-
     fn from_reader<R: Read>(reader: &mut R) -> Result<Self, Error>;
     fn to_writer<W: Write>(&self, writer: &mut W);
     fn from_slice(slice: &[u8]) -> Result<Self, Error> {
@@ -33,9 +31,9 @@ pub trait Serializable: Sized {
     }
 }
 
-pub trait ConstantSize {
-    const SIZE: usize;
-}
+// pub trait ConstantSize {
+//     const SIZE: usize;
+// }
 
 impl std::error::Error for Error {}
 impl std::fmt::Display for Error {

--- a/src/traits/serializable.rs
+++ b/src/traits/serializable.rs
@@ -31,10 +31,6 @@ pub trait Serializable: Sized {
     }
 }
 
-// pub trait ConstantSize {
-//     const SIZE: usize;
-// }
-
 impl std::error::Error for Error {}
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/traits/serializable/b_tree_map.rs
+++ b/src/traits/serializable/b_tree_map.rs
@@ -1,20 +1,12 @@
 use std::collections::BTreeMap;
 
-use crate::traits::{serializable, ConstantSize, Serializable};
+use crate::traits::{serializable, Serializable};
 
 impl<K, V> Serializable for BTreeMap<K, V>
 where
     K: Serializable + Ord,
     V: Serializable,
 {
-    fn serialized_size(&self) -> usize {
-        usize::SIZE
-            + self
-                .iter()
-                .map(|(k, v)| k.serialized_size() + v.serialized_size())
-                .sum::<usize>()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let size = usize::from_reader(reader)?;
         let mut map = BTreeMap::new();

--- a/src/traits/serializable/b_tree_set.rs
+++ b/src/traits/serializable/b_tree_set.rs
@@ -1,15 +1,11 @@
 use std::collections::BTreeSet;
 
-use crate::traits::serializable::{self, ConstantSize, Serializable};
+use crate::traits::serializable::{self, Serializable};
 
 impl<V> Serializable for BTreeSet<V>
 where
     V: Serializable + Ord,
 {
-    fn serialized_size(&self) -> usize {
-        usize::SIZE + self.iter().map(|v| v.serialized_size()).sum::<usize>()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let size = usize::from_reader(reader)?;
         let mut set = BTreeSet::new();

--- a/src/traits/serializable/box_.rs
+++ b/src/traits/serializable/box_.rs
@@ -4,10 +4,6 @@ impl<T> Serializable for Box<T>
 where
     T: Serializable,
 {
-    fn serialized_size(&self) -> usize {
-        self.as_ref().serialized_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let inner = T::from_reader(reader)?;
         Ok(Box::new(inner))

--- a/src/traits/serializable/hash_map.rs
+++ b/src/traits/serializable/hash_map.rs
@@ -4,21 +4,13 @@ use std::{
     io::{Read, Write},
 };
 
-use crate::traits::serializable::{ConstantSize, Error, Serializable};
+use crate::traits::serializable::{Error, Serializable};
 
 impl<K, V> Serializable for HashMap<K, V>
 where
     K: Serializable + Eq + Hash,
     V: Serializable,
 {
-    fn serialized_size(&self) -> usize {
-        usize::SIZE
-            + self
-                .iter()
-                .map(|(k, v)| k.serialized_size() + v.serialized_size())
-                .sum::<usize>()
-    }
-
     fn from_reader<R: Read>(reader: &mut R) -> Result<Self, Error> {
         let size = usize::from_reader(reader)?;
 

--- a/src/traits/serializable/message_id.rs
+++ b/src/traits/serializable/message_id.rs
@@ -3,10 +3,6 @@ use libp2p::gossipsub::MessageId;
 use crate::traits::{serializable, Serializable};
 
 impl Serializable for MessageId {
-    fn serialized_size(&self) -> usize {
-        self.0.serialized_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         Ok(MessageId(Vec::from_reader(reader)?))
     }

--- a/src/traits/serializable/multiaddr.rs
+++ b/src/traits/serializable/multiaddr.rs
@@ -1,12 +1,8 @@
 use libp2p::Multiaddr;
 
-use crate::traits::{serializable, ConstantSize, Serializable};
+use crate::traits::{serializable, Serializable};
 
 impl Serializable for Multiaddr {
-    fn serialized_size(&self) -> usize {
-        usize::SIZE + self.len()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let size = usize::from_reader(reader)?;
 

--- a/src/traits/serializable/multihash.rs
+++ b/src/traits/serializable/multihash.rs
@@ -2,14 +2,10 @@ use libp2p::multihash;
 
 use crate::{
     crypto::Multihash,
-    traits::{serializable, ConstantSize, Serializable},
+    traits::{serializable, Serializable},
 };
 
 impl Serializable for Multihash {
-    fn serialized_size(&self) -> usize {
-        u64::SIZE + u8::SIZE + self.digest().len()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let code = u64::from_reader(reader)?;
         let size = u8::from_reader(reader)?;

--- a/src/traits/serializable/numeric.rs
+++ b/src/traits/serializable/numeric.rs
@@ -1,15 +1,11 @@
 use std::io::{Read, Write};
 
-use crate::traits::serializable::{ConstantSize, Error, Serializable};
+use crate::traits::serializable::{Error, Serializable};
 
 macro_rules! impl_serializable_for_numeric {
     ($($type:ty),*) => {
         $(
             impl Serializable for $type {
-                fn serialized_size(&self) -> usize {
-                    size_of::<$type>()
-                }
-
                 fn from_reader<R: Read>(reader: &mut R) -> Result<Self, Error> {
                     let mut buffer = [0u8; size_of::<$type>()];
                     reader.read_exact(&mut buffer)?;
@@ -19,10 +15,6 @@ macro_rules! impl_serializable_for_numeric {
                 fn to_writer<W: Write>(&self, writer: &mut W) {
                     writer.write_all(&self.to_ne_bytes()).expect("Failed to write numeric value");
                 }
-            }
-
-            impl ConstantSize for $type {
-                const SIZE: usize = size_of::<$type>();
             }
         )*
     };

--- a/src/traits/serializable/option.rs
+++ b/src/traits/serializable/option.rs
@@ -1,18 +1,11 @@
 use std::io::{Read, Write};
 
-use crate::traits::serializable::{ConstantSize, Error, Serializable};
+use crate::traits::serializable::{Error, Serializable};
 
 impl<T> Serializable for Option<T>
 where
     T: Serializable,
 {
-    fn serialized_size(&self) -> usize {
-        1 + match self {
-            Some(value) => value.serialized_size(),
-            None => 0,
-        }
-    }
-
     fn from_reader<R: Read>(reader: &mut R) -> Result<Self, Error> {
         match u8::from_reader(reader)? {
             1 => Ok(Some(T::from_reader(reader)?)),
@@ -30,11 +23,4 @@ where
             None => 0u8.to_writer(writer),
         }
     }
-}
-
-impl<T> ConstantSize for Option<T>
-where
-    T: ConstantSize,
-{
-    const SIZE: usize = 1 + T::SIZE;
 }

--- a/src/traits/serializable/peer_id.rs
+++ b/src/traits/serializable/peer_id.rs
@@ -3,10 +3,6 @@ use libp2p::{multihash::Multihash, PeerId};
 use crate::traits::{serializable, Serializable};
 
 impl Serializable for PeerId {
-    fn serialized_size(&self) -> usize {
-        self.as_ref().serialized_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let multihash = Multihash::from_reader(reader)?;
         PeerId::from_multihash(multihash)

--- a/src/traits/serializable/string.rs
+++ b/src/traits/serializable/string.rs
@@ -1,10 +1,6 @@
-use crate::traits::{serializable, ConstantSize, Serializable};
+use crate::traits::{serializable, Serializable};
 
 impl Serializable for String {
-    fn serialized_size(&self) -> usize {
-        usize::SIZE + self.len()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let size = usize::from_reader(reader)?;
         let mut buffer = vec![0; size];
@@ -14,6 +10,8 @@ impl Serializable for String {
 
     fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
         self.len().to_writer(writer);
-        writer.write_all(self.as_bytes());
+        writer
+            .write_all(self.as_bytes())
+            .expect("Failed to write string");
     }
 }

--- a/src/traits/serializable/tuple.rs
+++ b/src/traits/serializable/tuple.rs
@@ -1,14 +1,10 @@
-use crate::traits::{serializable, ConstantSize, Serializable};
+use crate::traits::{serializable, Serializable};
 
 impl<A, B> Serializable for (A, B)
 where
     A: Serializable,
     B: Serializable,
 {
-    fn serialized_size(&self) -> usize {
-        self.0.serialized_size() + self.1.serialized_size()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let a = A::from_reader(reader)?;
         let b = B::from_reader(reader)?;
@@ -19,12 +15,4 @@ where
         self.0.to_writer(writer);
         self.1.to_writer(writer);
     }
-}
-
-impl<A, B> ConstantSize for (A, B)
-where
-    A: ConstantSize,
-    B: ConstantSize,
-{
-    const SIZE: usize = A::SIZE + B::SIZE;
 }

--- a/src/traits/serializable/vec.rs
+++ b/src/traits/serializable/vec.rs
@@ -1,17 +1,9 @@
-use crate::traits::{serializable, ConstantSize, Serializable};
+use crate::traits::{serializable, Serializable};
 
 impl<T> Serializable for Vec<T>
 where
     T: Serializable,
 {
-    fn serialized_size(&self) -> usize {
-        usize::SIZE
-            + self
-                .iter()
-                .map(|item| item.serialized_size())
-                .sum::<usize>()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let size = usize::from_reader(reader)?;
         let mut vec = Vec::with_capacity(size);

--- a/src/utils/mpt/node.rs
+++ b/src/utils/mpt/node.rs
@@ -184,10 +184,6 @@ impl Default for Flags {
 }
 
 impl Serializable for Full {
-    fn serialized_size(&self) -> usize {
-        unimplemented!()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let mut children = std::array::from_fn(|_| Node::Empty);
 
@@ -210,10 +206,6 @@ impl Serializable for Full {
 }
 
 impl Serializable for Short {
-    fn serialized_size(&self) -> usize {
-        unimplemented!()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let len = u8::from_reader(reader)?;
         let mut vec = vec![0u8; len as usize];
@@ -242,10 +234,6 @@ impl Serializable for Short {
 }
 
 impl Serializable for Node {
-    fn serialized_size(&self) -> usize {
-        unimplemented!()
-    }
-
     fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, serializable::Error> {
         let tag = u8::from_reader(reader)?;
 


### PR DESCRIPTION
- Eliminate ConstantSize trait and all usages
- Remove serialized_size from Serializable implementations
- Update imports and trait bounds accordingly