### PR TITLE
feat: add civita-serialize crate with basic Serialize impls

### DIFF
--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "civita-serialize"
+version.workspace = true
+edition.workspace = true
+
+[features]
+libp2p = ["dep:libp2p"]
+
+[dependencies]
+libp2p = { version = "0.56", optional = true }

--- a/serialize/src/implements.rs
+++ b/serialize/src/implements.rs
@@ -1,0 +1,7 @@
+pub mod numeric;
+pub mod option;
+pub mod string;
+pub mod vec;
+
+#[cfg(feature = "libp2p")]
+pub mod libp2p;

--- a/serialize/src/implements/libp2p.rs
+++ b/serialize/src/implements/libp2p.rs
@@ -1,0 +1,35 @@
+use libp2p::{multihash::Multihash, PeerId};
+
+use crate::*;
+
+impl<const N: usize> Serialize for Multihash<N> {
+    fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self> {
+        let code = u64::from_reader(reader)?;
+        let size = u8::from_reader(reader)?;
+
+        let mut digest = vec![0; size as usize];
+        reader.read_exact(&mut digest)?;
+
+        Multihash::wrap(code, &digest).map_err(|e| Error(e.to_string()))
+    }
+
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.code().to_writer(writer);
+        self.size().to_writer(writer);
+        writer
+            .write_all(self.digest())
+            .expect("Failed to write digest");
+    }
+}
+
+impl Serialize for PeerId {
+    fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self> {
+        let multihash = Multihash::from_reader(reader)?;
+        PeerId::from_multihash(multihash)
+            .map_err(|_| Error("Failed to convert Multihash to PeerId".to_string()))
+    }
+
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.as_ref().to_writer(writer)
+    }
+}

--- a/serialize/src/implements/numeric.rs
+++ b/serialize/src/implements/numeric.rs
@@ -1,0 +1,25 @@
+use std::io::{Read, Write};
+
+use crate::*;
+
+macro_rules! impl_serialize_for_numeric {
+    ($($type:ty),*) => {
+        $(
+            impl Serialize for $type {
+                fn from_reader<R: Read>(reader: &mut R) -> Result<Self> {
+                    let mut buffer = [0u8; size_of::<$type>()];
+                    reader.read_exact(&mut buffer)?;
+                    Ok(<$type>::from_ne_bytes(buffer))
+                }
+
+                fn to_writer<W: Write>(&self, writer: &mut W) {
+                    writer.write_all(&self.to_ne_bytes()).expect("Failed to write numeric value");
+                }
+            }
+        )*
+    };
+}
+
+impl_serialize_for_numeric!(
+    i8, i16, i32, i64, i128, u8, u16, u32, u64, u128, usize, isize, f32, f64
+);

--- a/serialize/src/implements/option.rs
+++ b/serialize/src/implements/option.rs
@@ -1,0 +1,23 @@
+use std::io::{Read, Write};
+
+use crate::*;
+
+impl<T: Serialize> Serialize for Option<T> {
+    fn from_reader<R: Read>(reader: &mut R) -> Result<Self> {
+        match u8::from_reader(reader)? {
+            1 => Ok(Some(T::from_reader(reader)?)),
+            0 => Ok(None),
+            i => Err(Error(format!("Unknown option flag: {i}"))),
+        }
+    }
+
+    fn to_writer<W: Write>(&self, writer: &mut W) {
+        match self {
+            Some(value) => {
+                1u8.to_writer(writer);
+                value.to_writer(writer);
+            }
+            None => 0u8.to_writer(writer),
+        }
+    }
+}

--- a/serialize/src/implements/string.rs
+++ b/serialize/src/implements/string.rs
@@ -1,0 +1,17 @@
+use crate::*;
+
+impl Serialize for String {
+    fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self> {
+        let size = usize::from_reader(reader)?;
+        let mut buffer = vec![0; size];
+        reader.read_exact(&mut buffer)?;
+        String::from_utf8(buffer).map_err(|e| Error(e.to_string()))
+    }
+
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
+        writer
+            .write_all(self.as_bytes())
+            .expect("Failed to write string");
+    }
+}

--- a/serialize/src/implements/vec.rs
+++ b/serialize/src/implements/vec.rs
@@ -1,0 +1,22 @@
+use crate::*;
+
+impl<T> Serialize for Vec<T>
+where
+    T: Serialize,
+{
+    fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self> {
+        let size = usize::from_reader(reader)?;
+        let mut vec = Vec::with_capacity(size);
+        for _ in 0..size {
+            vec.push(T::from_reader(reader)?);
+        }
+        Ok(vec)
+    }
+
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
+        for item in self {
+            item.to_writer(writer);
+        }
+    }
+}

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -1,0 +1,33 @@
+pub mod implements;
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct Error(pub String);
+
+pub trait Serialize: Sized {
+    fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self, Error>;
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W);
+    fn from_slice(slice: &[u8]) -> Result<Self, Error> {
+        let mut reader = slice;
+        Self::from_reader(&mut reader)
+    }
+    fn to_vec(&self) -> Vec<u8> {
+        let mut writer = Vec::new();
+        self.to_writer(&mut writer);
+        writer
+    }
+}
+
+impl std::error::Error for Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error(e.to_string())
+    }
+}


### PR DESCRIPTION
- Implement Serialize trait for numeric types, Option, String, Vec
- Add optional libp2p support for PeerId and Multihash
- Provide error handling and utility methods in core trait