### PR TITLE
chore: set workspace resolver to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["core", "serialize", "serialize-derive"]
+resolver = "2"
 
 [workspace.package]
 name = "civita"


### PR DESCRIPTION
- Adds `resolver = "2"` to Cargo.toml workspace
- Ensures modern dependency resolution for Rust projects