### PR TITLE
feat: derive Serialize for Witness and Proposal structs

### DIFF
--- a/core/src/proposal.rs
+++ b/core/src/proposal.rs
@@ -46,6 +46,7 @@ pub struct Payload {
 #[derive(Clone)]
 #[derive(Debug)]
 #[derive(Eq, PartialEq)]
+#[derive(Serialize)]
 pub struct Witness {
     pub sig: Signature,
     pub proofs: ProofDb,
@@ -55,6 +56,7 @@ pub struct Witness {
 #[derive(Clone)]
 #[derive(Debug)]
 #[derive(Eq, PartialEq)]
+#[derive(Serialize)]
 pub struct Proposal {
     pub payload: Payload,
     pub witness: Witness,


### PR DESCRIPTION
- Add #[derive(Serialize)] to Witness and Proposal
- Enables serialization support for these types