### PR TITLE
refactor: rename MerklePatriciaTrie to Trie

### DIFF
--- a/core/src/proposal.rs
+++ b/core/src/proposal.rs
@@ -11,7 +11,7 @@ use vdf::{WesolowskiVDF, VDF};
 use crate::{
     crypto::{Hasher, Multihash, PublicKey, SecretKey, Signature},
     resident,
-    utils::mpt::{self, MerklePatriciaTrie},
+    utils::mpt::{self, Trie},
 };
 
 type ProofDb = HashMap<Multihash, Vec<u8>>;
@@ -89,7 +89,7 @@ impl Witness {
         root_hash: Multihash,
         vdf_difficulty: u64,
         vdf: WesolowskiVDF,
-        mpt: &MerklePatriciaTrie<H, S>,
+        mpt: &Trie<H, S>,
     ) -> bool {
         if payload.parent_root != root_hash {
             return false;
@@ -119,7 +119,7 @@ impl Witness {
     fn verify_proposer<H: Hasher, S: mpt::Storage>(
         &self,
         payload: &Payload,
-        mpt: &MerklePatriciaTrie<H, S>,
+        mpt: &Trie<H, S>,
     ) -> bool {
         let key = payload.proposer_pk.to_hash::<H>().to_bytes();
 
@@ -133,11 +133,7 @@ impl Witness {
         record.stakes == payload.proposal_stakes
     }
 
-    fn verify_diff<H: Hasher, S: mpt::Storage>(
-        &self,
-        payload: &Payload,
-        mpt: &MerklePatriciaTrie<H, S>,
-    ) -> bool {
+    fn verify_diff<H: Hasher, S: mpt::Storage>(&self, payload: &Payload, mpt: &Trie<H, S>) -> bool {
         for (key, diff) in &payload.diff {
             let Some(bytes) = mpt.verify_proof(key, &self.proofs) else {
                 return false;
@@ -165,7 +161,7 @@ impl Proposal {
         root_hash: Multihash,
         vdf_difficulty: u64,
         vdf: WesolowskiVDF,
-        mpt: &MerklePatriciaTrie<H, S>,
+        mpt: &Trie<H, S>,
     ) -> bool {
         self.witness
             .verify(&self.payload, root_hash, vdf_difficulty, vdf, mpt)

--- a/core/src/utils/mpt.rs
+++ b/core/src/utils/mpt.rs
@@ -28,16 +28,16 @@ pub enum Error {
     MissingNode,
 }
 
-pub struct MerklePatriciaTrie<H, S> {
+pub struct Trie<H, S> {
     root: Node,
     storage: S,
     cache: HashMap<Multihash, Node>,
     _marker: PhantomData<H>,
 }
 
-impl<H: Hasher, S: Storage> MerklePatriciaTrie<H, S> {
+impl<H: Hasher, S: Storage> Trie<H, S> {
     pub fn empty(storage: S) -> Self {
-        MerklePatriciaTrie {
+        Trie {
             root: Node::Empty,
             storage,
             cache: HashMap::new(),
@@ -46,7 +46,7 @@ impl<H: Hasher, S: Storage> MerklePatriciaTrie<H, S> {
     }
 
     pub fn from_root(root_hash: Multihash, storage: S) -> Self {
-        MerklePatriciaTrie {
+        Trie {
             root: Node::Hash(root_hash),
             storage,
             cache: HashMap::new(),
@@ -403,7 +403,7 @@ mod tests {
     use super::*;
 
     type TestHasher = sha2::Sha256;
-    type TestMerklePatriciaTrie = MerklePatriciaTrie<TestHasher, HashMap<Multihash, Vec<u8>>>;
+    type TestMerklePatriciaTrie = Trie<TestHasher, HashMap<Multihash, Vec<u8>>>;
 
     const KEY: &[u8] = &[1, 2, 3, 4];
     const VALUE: &[u8] = &[5, 6, 7, 8];


### PR DESCRIPTION
- Update all references from MerklePatriciaTrie to Trie
- Simplify naming for clarity and consistency