### PR TITLE
feat: add Serialize impl for HashSet

### DIFF
--- a/serialize/src/implements.rs
+++ b/serialize/src/implements.rs
@@ -3,6 +3,7 @@ pub mod b_tree;
 pub mod bool;
 pub mod box_;
 pub mod hash_map;
+pub mod hash_set;
 pub mod numeric;
 pub mod option;
 pub mod string;

--- a/serialize/src/implements/hash_set.rs
+++ b/serialize/src/implements/hash_set.rs
@@ -1,0 +1,22 @@
+use std::{collections::HashSet, hash::Hash};
+
+use crate::*;
+
+impl<T: Serialize + Eq + Hash> Serialize for HashSet<T> {
+    fn from_reader<R: std::io::Read>(reader: &mut R) -> Result<Self> {
+        let len = u64::from_reader(reader)?;
+        let mut set = HashSet::new();
+        for _ in 0..len {
+            let item = T::from_reader(reader)?;
+            set.insert(item);
+        }
+        Ok(set)
+    }
+
+    fn to_writer<W: std::io::Write>(&self, writer: &mut W) {
+        self.len().to_writer(writer);
+        self.iter().for_each(|item| {
+            item.to_writer(writer);
+        });
+    }
+}


### PR DESCRIPTION
- Implement Serialize for std::collections::HashSet<T>
- Support reading/writing HashSet via from_reader/to_writer
- Register hash_set module in implements.rs