### PR TITLE
refactor: add generic hasher to append_proposals method

### DIFF
--- a/core/src/block/tree.rs
+++ b/core/src/block/tree.rs
@@ -344,12 +344,12 @@ impl Tree {
         self.ancestors_cache.clear();
     }
 
-    pub fn append_proposals<I>(&mut self, proposals: I)
+    pub fn append_proposals<H: Hasher, I>(&mut self, proposals: I)
     where
         I: IntoIterator<Item = Proposal>,
     {
         for proposal in proposals {
-            let hash = proposal.hash();
+            let hash = proposal.hash::<H>();
             let checkpoint_hash = proposal.parent_checkpoint;
 
             if let Some(subtree) = self.subtrees.get_mut(&checkpoint_hash) {


### PR DESCRIPTION
- Add Hasher type parameter to append_proposals method
- Update proposal.hash() call to use generic hasher type