### PR TITLE
refactor: replace HashSet with BTreeSet for proposals

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     sync::OnceLock,
 };
 
@@ -29,7 +29,7 @@ pub enum Error {
 #[derive(Eq, PartialEq)]
 #[derive(Serialize)]
 pub struct Block {
-    pub proposals: HashSet<Multihash>,
+    pub proposals: BTreeSet<Multihash>,
     pub parent: Multihash,
     pub parent_checkpoint: Multihash,
     pub height: u64,


### PR DESCRIPTION
- Change proposals field from HashSet to BTreeSet in Block struct
- Update import to use BTreeSet instead of HashSet
- Provides deterministic ordering for proposals