### PR TITLE
feat: add request-response protocol support to network layer

### DIFF
--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -2,6 +2,7 @@ mod behaviour;
 
 pub mod cache_storage;
 pub mod gossipsub;
+pub mod request_response;
 pub mod storage;
 pub mod transport;
 

--- a/core/src/network/request_response.rs
+++ b/core/src/network/request_response.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+
+use libp2p::{
+    request_response::{self, ResponseChannel},
+    Swarm,
+};
+use tokio::sync::Mutex;
+
+use crate::network::behaviour::Behaviour;
+
+mod network;
+
+type Event = request_response::Event<Vec<u8>, Vec<u8>>;
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+#[derive(thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Network(#[from] network::Error),
+}
+
+pub enum RequestResponse {
+    Network(network::RequestResponse),
+}
+
+impl RequestResponse {
+    pub fn new_network(swarm: Arc<Mutex<Swarm<Behaviour>>>) -> Self {
+        Self::Network(network::RequestResponse::new(swarm))
+    }
+
+    pub async fn handle_event_network(&self, event: Event) -> Result<()> {
+        match self {
+            Self::Network(network) => network.handle_event(event).await.map_err(Error::from),
+        }
+    }
+
+    pub async fn send_request_network(
+        &self,
+        peer_id: libp2p::PeerId,
+        request: Vec<u8>,
+    ) -> Result<()> {
+        match self {
+            Self::Network(network) => network
+                .send_request(peer_id, request)
+                .await
+                .map_err(Error::from),
+        }
+    }
+
+    pub async fn send_response_network(
+        &self,
+        ch: ResponseChannel<Vec<u8>>,
+        response: Vec<u8>,
+    ) -> Result<()> {
+        match self {
+            Self::Network(network) => network
+                .send_response(ch, response)
+                .await
+                .map_err(Error::from),
+        }
+    }
+}

--- a/core/src/network/request_response/network.rs
+++ b/core/src/network/request_response/network.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use libp2p::{
+    request_response::{self, ResponseChannel},
+    PeerId, Swarm,
+};
+use tokio::sync::{mpsc, Mutex};
+
+use crate::network::{behaviour::Behaviour, request_response::Event};
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+type Message = request_response::Message<Vec<u8>, Vec<u8>>;
+
+#[derive(Debug)]
+#[derive(thiserror::Error)]
+pub enum Error {
+    #[error("Failed to send response")]
+    SendResponse,
+
+    #[error("{0}")]
+    SendError(String),
+}
+
+pub struct RequestResponse {
+    swarm: Arc<Mutex<Swarm<Behaviour>>>,
+    tx: Option<mpsc::Sender<Message>>,
+}
+
+impl RequestResponse {
+    pub fn new(swarm: Arc<Mutex<Swarm<Behaviour>>>) -> Self {
+        Self { swarm, tx: None }
+    }
+
+    pub async fn handle_event(&self, event: Event) -> Result<()> {
+        if let Event::Message { message, .. } = event {
+            if let Some(tx) = &self.tx {
+                tx.send(message).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn send_request(&self, peer_id: PeerId, request: Vec<u8>) -> Result<()> {
+        let mut swarm = self.swarm.lock().await;
+        let _ = swarm
+            .behaviour_mut()
+            .req_resp_mut()
+            .send_request(&peer_id, request);
+        Ok(())
+    }
+
+    pub async fn send_response(
+        &self,
+        ch: ResponseChannel<Vec<u8>>,
+        response: Vec<u8>,
+    ) -> Result<()> {
+        let mut swarm = self.swarm.lock().await;
+        swarm
+            .behaviour_mut()
+            .req_resp_mut()
+            .send_response(ch, response)
+            .map_err(|_| Error::SendResponse)?;
+        Ok(())
+    }
+}
+
+impl From<mpsc::error::SendError<Message>> for Error {
+    fn from(e: mpsc::error::SendError<Message>) -> Self {
+        Error::SendError(e.to_string())
+    }
+}


### PR DESCRIPTION
- Integrate libp2p request-response behavior with CBOR codec
- Add RequestResponse wrapper with network implementation
- Update transport layer to handle request-response events
- Expose request/response methods for peer communication